### PR TITLE
Incorporated Knuth's integer division algorithm, D into Limbs.divMod

### DIFF
--- a/Euler.xcodeproj/project.pbxproj
+++ b/Euler.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		45C423802509687A00D22532 /* KnuthDSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4237F2509687A00D22532 /* KnuthDSupport.swift */; };
 		68834B1424E98B3F004D709C /* ExpressionSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68834B1324E98B3F004D709C /* ExpressionSolver.swift */; };
 		689F568324912A89003097E2 /* CommonLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689F568224912A89003097E2 /* CommonLinker.swift */; };
 		689F568524912B0F003097E2 /* LogicalLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689F568424912B0F003097E2 /* LogicalLinker.swift */; };
@@ -136,6 +137,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		45C4237F2509687A00D22532 /* KnuthDSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnuthDSupport.swift; sourceTree = "<group>"; };
 		68834B1324E98B3F004D709C /* ExpressionSolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionSolver.swift; sourceTree = "<group>"; };
 		689F568224912A89003097E2 /* CommonLinker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonLinker.swift; sourceTree = "<group>"; };
 		689F568424912B0F003097E2 /* LogicalLinker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogicalLinker.swift; sourceTree = "<group>"; };
@@ -564,6 +566,7 @@
 				OBJ_94 /* UnsafeMemory.swift */,
 				OBJ_95 /* UnsafeMutableMemory.swift */,
 				68C12AD22483392C00BB4B3A /* Substring.swift */,
+				45C4237F2509687A00D22532 /* KnuthDSupport.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -739,6 +742,7 @@
 				OBJ_223 /* leastFactor.swift in Sources */,
 				OBJ_224 /* modulo.swift in Sources */,
 				OBJ_225 /* random.swift in Sources */,
+				45C423802509687A00D22532 /* KnuthDSupport.swift in Sources */,
 				OBJ_226 /* sum.swift in Sources */,
 				68ADEAD524843775006C65CD /* DateTime.swift in Sources */,
 				OBJ_227 /* Average.swift in Sources */,

--- a/Sources/Euler/BigNumber/Limbs.swift
+++ b/Sources/Euler/BigNumber/Limbs.swift
@@ -682,7 +682,6 @@ internal extension Array where Element == Limb {
         quotient: inout Limbs,
         remainder: inout Limbs)
     {
-        typealias Digit = UInt64
         typealias TwoLimbs = (high: UInt64, low: UInt64)
         let digitWidth = Digit.bitWidth
         let m = dividend.count

--- a/Sources/Euler/BigNumber/Limbs.swift
+++ b/Sources/Euler/BigNumber/Limbs.swift
@@ -584,56 +584,54 @@ internal extension Array where Element == Limb {
         precondition(!divisor.equalTo(0), "Division or Modulo by zero not allowed")
         
         #if true
-        /*
-         Knuth's algorithm requires the dividend to be greater than the the
-         divisor. If divisor is greater, the quotient is immediately known to
-         be 0, and the remainder is the dividend.  Since limbs are maintained
-         without leading zeros, most cases of the dividend being greater than
-         the divisor can be handled by just checking the number of limbs they
-         contain, which is a fast O(1) check.  Only when the number of limbs are
-         equal is an O(n) compare required.
-         */
+        
+        // Handle the case of a divisor greater than the dividend.  The fast
+        // test of limb counts is based on Euler maintaining limbs without
+        // leading zeros.
         if divisor.count > self.count
             || (divisor.count == self.count && self.lessThan(divisor))
         {
             return (quotient: [0], remainder: self)
         }
         
-        // If divisor has just 1 digit, we can do an even more efficient divide
         guard divisor.count > 1 else
         {
+            // Knuth's algorithm requires at least 2 divisor digits, so handle
+            // that case specially.
             var q = Limbs(repeating: 0, count: self.count)
             let r = divide(self, by: divisor.first!, result: &q)
             while q.count > 1 && q.last! == 0 { q.removeLast() }
             return (quotient: q, remainder: [r])
         }
 
+        /*
+         The actual algorithm starts here.  The variable names, u, v, m, and n
+         are based on the names published in Knuth's Alogirthm D in his The Art
+         of Computer Programming, and are maintained so that anyone following
+         the algorithm from TAOCP can identify them in this code.  For
+         everyone else, here's a legend:
+         
+                u = the normalized dividend that is transformed into the
+                    remainder (initially a normalized copy of self).
+                v = the normalized divisor
+                m = the number of limbs in the dividend
+                n = the number of limbs in the divisor
+         */
         let maxQuotientSize = self.count - divisor.count + 1
-        let maxRemanderSize = divisor.count
         var quotient = Limbs(repeating: 0, count: maxQuotientSize)
-        var remainder = Limbs(repeating: 0, count: maxRemanderSize)
-        
+
         typealias TwoLimbs = (high: UInt64, low: UInt64)
         let digitWidth = Digit.bitWidth
         let m = self.count
         let n = divisor.count
         
-        assert(m >= n, "Dividend must have at least as many limbs as the divisor")
-        assert(
-            quotient.count >= m - n + 1,
-            "Must have space for the number of limbs in the dividend minus the "
-            + "number of digits in the divisor plus one more limbs."
-        )
-        assert(
-            remainder.count == n,
-            "Remainder must have space for the same number of limbs as the divisor"
-        )
-        
+        // Normalize divisor so its most significant bit is 1.
         let shift = divisor.last!.leadingZeroBitCount
-        
         var v = Limbs(repeating: 0, count: n)
         leftShift(divisor, by: shift, into: &v)
-
+        
+        // Normalize dividend by the same amount so its ratio with the divisor
+        // is maintained.
         var u = Limbs(repeating: 0, count: m + 1)
         u[m] = self[m - 1] >> (digitWidth - shift)
         leftShift(self, by: shift, into: &u)
@@ -648,12 +646,18 @@ internal extension Array where Element == Limb {
             
             let dividendHead: TwoLimbs = (high: u[jPlusN], low: u[jPlusN &- 1])
             
+            // Compute estimated quotient digit, q̂, and partial remainder, r̂
             // These are tuple arithemtic operations.  `/%` is custom combined
             // division and remainder operator.  See TupleMath.swift
             var (q̂, r̂) = dividendHead /% vLast
             var partialProduct = q̂ * vNextToLast
             var partialDividend:TwoLimbs = (high: r̂.low, low: u[jPlusN &- 2])
             
+            // Revise estimated q̂ based on the first two digits of the divisor
+            // and first two digits of the dividend.  It corrects most of the
+            // cases when q̂ is one too big, and all of the cases when q̂ is two
+            // too big.
+            // Corresponds to Step D3 in TAOCP
             while true
             {
                 if (UInt8(q̂.high != 0) | (partialProduct > partialDividend)) == 1
@@ -668,26 +672,34 @@ internal extension Array where Element == Limb {
                 break
             }
 
+            // Set quotient digit, and compute an updated remainder
             quotient[j] = q̂.low
-            
             if subtractReportingBorrow(v[0..<n], times: q̂.low, from: &u[j...jPlusN])
             {
+                // If the subtraction borrowed out of the high limb, then q̂
+                // was still one too big, so decrement it and adjust the
+                // updated remainder.  Because of the above while loop, this is
+                // rare, but possible.
                 quotient[j] &-= 1
-                u[j...jPlusN] += v[0..<n] // digit collection addition!
+                u[j...jPlusN] += v[0..<n] // Limbs subsequence addition!
             }
         }
         
-        rightShift(u[0..<n], by: shift, into: &remainder)
+        // Quotient is already correct, but remainder needs denormalization
+        rightShift(&u[0..<n], by: shift)
 
-        // The aglorithm leaves leading zeros, so they are stripped
+        // The division algorithm is done, but now we clean up the results for
+        // Euler's requirements. quotient and remainder both may have leading
+        // zeros that need removing.
         while quotient.count > 1 && quotient.last! == 0 {
             quotient.removeLast()
         }
-        while remainder.count > 1 && remainder.last! == 0 {
-            remainder.removeLast()
-        }
+        while u.count > 1 && u.last! == 0 { u.removeLast() }
+        
+        return (quotient, u)
 
         #else // original shift-subtract algorithm is left here for now
+        
         if self.equalTo(0) { return ([0], [0]) }
         
         if self.lessThan(divisor) { return ([0], self) }
@@ -721,9 +733,9 @@ internal extension Array where Element == Limb {
             
             i -= 1
         }
-        #endif
         
         return (quotient, remainder)
+        #endif
     }
     
     /// Division with limbs, result is floored to nearest whole number.

--- a/Sources/Euler/Utility/KnuthDSupport.swift
+++ b/Sources/Euler/Utility/KnuthDSupport.swift
@@ -1,0 +1,335 @@
+//
+//  KnuthDSupport.swift
+//  Euler
+//
+//  Created by Chip Jarred on 9/9/20.
+//
+
+// -------------------------------------
+internal extension FixedWidthInteger
+{
+    // -------------------------------------
+    /// Fast creation of an integer from a Bool
+    @usableFromInline @inline(__always) init(_ source: Bool)
+    {
+        assert(unsafeBitCast(source, to: UInt8.self) & 0xfe == 0)
+        self.init(unsafeBitCast(source, to: UInt8.self))
+    }
+}
+
+// -------------------------------------
+/**
+ Subtract two `FixedWidthInteger`s, `x`, and `y`, storing the result back to
+ `y`. (ie. `x -= y`)
+ 
+ - Parameters:
+    - x: The minuend and recipient of the resulting difference.
+    - y: The subtrahend
+ 
+ - Returns: Borrow out of the difference.
+ */
+@usableFromInline @inline(__always)
+func subtractReportingBorrow<T: FixedWidthInteger>(_ x: inout T, _ y: T) -> T
+{
+    let b: Bool
+    (x, b) = x.subtractingReportingOverflow(y)
+    return T(b)
+}
+
+// -------------------------------------
+/**
+ Add two `FixedWidthInteger`s, `x`, and `y`, storing the result back to `x`.
+ (ie. `x += y`)
+ 
+ - Parameters:
+    - x: The first addend and recipient of the resulting sum.
+    - y: The second addend
+ 
+ - Returns: Carry out of the sum.
+ */
+@usableFromInline @inline(__always)
+func addReportingCarry<T: FixedWidthInteger>(_ x: inout T, _ y: T) -> T
+{
+    let c: Bool
+    (x, c) = x.addingReportingOverflow(y)
+    return T(c)
+}
+
+// -------------------------------------
+/**
+ Compute `y = y - x * k`
+ 
+ - Parameters:
+    - x: A multiprecision number with the least signficant digit
+        stored at index 0 (ie. little endian).  It is multiplied by the "digit",
+        `k`, with the resulting product being subtracted from `y`
+    - k: Scalar multiple to apply to `x` prior to subtraction
+    - y: Both the number being subtracted from, and the storage for the result,
+        represented as a collection of digits with the least signficant digits
+        at index 0.
+ 
+ - Returns: The borrow out of the most signficant digit of `y`.
+ */
+@usableFromInline @inline(__always)
+func subtractReportingBorrow<T, U>(
+    _ x: T,
+    times k: T.Element,
+    from y: inout U) -> Bool
+    where T: RandomAccessCollection,
+    T.Element == UInt64,
+    T.Element.Magnitude == T.Element,
+    T.Index == Int,
+    U: RandomAccessCollection,
+    U: MutableCollection,
+    U.Element == T.Element,
+    U.Index == T.Index
+{
+    assert(x.count + 1 <= y.count)
+    
+    var i = x.startIndex
+    var j = y.startIndex
+
+    var borrow: T.Element = 0
+    while i < x.endIndex
+    {
+        borrow = subtractReportingBorrow(&y[j], borrow)
+        let (pHi, pLo) = k.multipliedFullWidth(by: x[i])
+        borrow &+= pHi
+        borrow &+= subtractReportingBorrow(&y[j], pLo)
+        
+        i &+= 1
+        j &+= 1
+    }
+    
+    return 0 != subtractReportingBorrow(&y[j], borrow)
+}
+
+// -------------------------------------
+/**
+ Add two multiprecision numbers.
+ 
+ - Parameters:
+    - x: The first addend as a collection digits with the least signficant
+        digit at index 0 (ie. little endian).
+    - y: The second addend and the storage for the resulting sum as a
+        collection of digits with the the least signficant digit at index 0
+        (ie. little endian).
+ */
+@usableFromInline @inline(__always)
+func += <T, U>(left: inout U, right: T )
+    where T: RandomAccessCollection,
+    T.Element == UInt64,
+    T.Index == Int,
+    U: RandomAccessCollection,
+    U: MutableCollection,
+    U.Element == T.Element,
+    U.Index == T.Index
+{
+    assert(right.count + 1 == left.count)
+    var carry: T.Element = 0
+    
+    var i = right.startIndex
+    var j = left.startIndex
+    while i < right.endIndex
+    {
+        carry = addReportingCarry(&left[j], carry)
+        carry &+= addReportingCarry(&left[j], right[i])
+        
+        i &+= 1
+        j &+= 1
+    }
+    
+    left[j] &+= carry
+}
+
+// -------------------------------------
+/**
+ Shift the multiprecision unsigned integer, `x`, left by `shift` bits.
+ 
+ - Parameters:
+    - x: The mutliprecision unsigned integer to be left-shfited, stored as a
+        collection of digits with the least signficant digit stored at index 0.
+        (ie. little endian)
+    - shift: the number of bits to shift `x` by.
+    - y: Storage for the resulting shift of `x`.  May alias `x`.
+ */
+@usableFromInline @inline(__always)
+func leftShift<T, U>(_ x: T, by shift: Int, into y: inout U)
+    where
+    T: RandomAccessCollection,
+    T.Element == UInt64,
+    T.Index == Int,
+    U: RandomAccessCollection,
+    U: MutableCollection,
+    U.Element == T.Element,
+    U.Index == T.Index
+{
+    assert(y.count >= x.count)
+    assert(y.startIndex == x.startIndex)
+    
+    let bitWidth = MemoryLayout<T.Element>.size * 8
+    
+    for i in (1..<x.count).reversed() {
+        y[i] = (x[i] << shift) | (x[i - 1] >> (bitWidth - shift))
+    }
+    y[0] = x[0] << shift
+}
+
+// -------------------------------------
+/**
+ Shift the multiprecision unsigned integer,`x`, right by `shift` bits.
+ 
+ - Parameters:
+    - x: The mutliprecision unsigned integer to be right-shfited, stored as a
+        collection of digits with the least signficant digit stored at index 0.
+        (ie. little endian)
+    - shift: the number of bits to shift `x` by.
+    - y: Storage for the resulting shift of `x`.  May alias `x`.
+ */
+@usableFromInline @inline(__always)
+func rightShift<T, U>(_ x: T, by shift: Int, into y: inout U)
+    where
+    T: RandomAccessCollection,
+    T.Element:BinaryInteger,
+    T.Index == Int,
+    U: RandomAccessCollection,
+    U: MutableCollection,
+    U.Element == T.Element,
+    U.Index == T.Index
+{
+    assert(y.count == x.count)
+    assert(y.startIndex == x.startIndex)
+    let bitWidth = MemoryLayout<T.Element>.size * 8
+    
+    let lastElemIndex = x.count - 1
+    for i in 0..<lastElemIndex {
+        y[i] = (x[i] >> shift) | (x[i + 1] << (bitWidth - shift))
+    }
+    y[lastElemIndex] = x[lastElemIndex] >> shift
+}
+
+// -------------------------------------
+/**
+ Divide the multiprecision number stored in `x`, by the "digit",`y.`
+ 
+ - Parameters:
+    - x: The dividend as a multiprecision number with the least signficant digit
+        stored at index 0 (ie. little endian).
+    - y: The single digit divisor (where digit is the same radix as digits of
+        `x`).
+    - z: storage to receive the quotient on exit.  Must be same size as `x`
+
+- Returns: A single digit remainder.
+ */
+@usableFromInline @inline(__always)
+func divide<T, U>(_ x: T, by y: T.Element, result z: inout U) -> T.Element
+    where T: RandomAccessCollection,
+    T.Element == UInt64,
+    T.Index == Int,
+    U: RandomAccessCollection,
+    U: MutableCollection,
+    U.Element == T.Element,
+    U.Index == T.Index
+{
+    assert(x.count == z.count)
+    assert(x.startIndex == z.startIndex)
+    
+    var r: T.Element = 0
+    var i = x.count - 1
+    
+    (z[i], r) = x[i].quotientAndRemainder(dividingBy: y)
+    i -= 1
+    
+    while i >= 0
+    {
+        (z[i], r) = y.dividingFullWidth((r, x[i]))
+        i -= 1
+    }
+    return r
+}
+
+// MARK:- Tuple Arithmetic Operations
+/*
+The operators in this file implement the tuple operations for the 2-digit
+arithmetic needed for Knuth's Algorithm D, and *only* those operations.
+There is no attempt to be a complete set. They are meant to make the code that
+uses them more readable than if the operations they express were written out
+directly.
+*/
+
+// -------------------------------------
+/// Multiply a tuple of digits by 1 digit
+@usableFromInline @inline(__always)
+internal func * (left: (high: UInt64, low: UInt64), right: UInt64)
+    -> (high: UInt64, low: UInt64)
+{
+    var product = left.low.multipliedFullWidth(by: right)
+    let productHigh = left.high.multipliedFullWidth(by: right)
+    assert(productHigh.high == 0, "multiplication overflow")
+    let c = addReportingCarry(&product.high, productHigh.low)
+    assert(c == 0, "multiplication overflow")
+    
+    return product
+}
+
+infix operator /% : MultiplicationPrecedence
+
+// -------------------------------------
+/// Divide a tuple of digits by 1 digit obtaining both quotient and remainder
+@usableFromInline @inline(__always)
+internal func /% (left: (high: UInt64, low: UInt64), right: UInt64)
+    -> (
+        quotient: (high: UInt64, low: UInt64),
+        remainder: (high: UInt64, low: UInt64)
+    )
+{
+    var r: UInt64
+    let q: (high: UInt64, low: UInt64)
+    (q.high, r) = left.high.quotientAndRemainder(dividingBy: right)
+    (q.low, r) = right.dividingFullWidth((high: r, low: left.low))
+    
+    return (q, (high: 0, low: r))
+}
+
+// -------------------------------------
+/**
+ Tests if  the typle, `left`, is greater than tuple, `right`.
+ 
+ - Returns: `UInt8` that has the value of 1 if `left` is greater than right;
+    otherwise, 0.  This is done in place of returning a boolean as part of an
+    optimization to avoid hidden conditional branches in boolean expressions.
+ */
+
+@usableFromInline @inline(__always)
+internal func > (
+    left: (high: UInt64, low: UInt64),
+    right: (high: UInt64, low: UInt64)) -> UInt8
+{
+    return UInt8(left.high > right.high)
+        | (UInt8(left.high == right.high) & UInt8(left.low > right.low))
+}
+
+// -------------------------------------
+/// Add a digit to a tuple's low part, carrying to the high part.
+@usableFromInline @inline(__always)
+func += (left: inout (high: UInt64, low: UInt64), right: UInt64) {
+    left.high &+= addReportingCarry(&left.low, right)
+}
+
+// -------------------------------------
+/// Add one tuple to another tuple
+@usableFromInline @inline(__always)
+func += (
+    left: inout (high: UInt64, low: UInt64),
+    right: (high: UInt64, low: UInt64))
+{
+    left.high &+= addReportingCarry(&left.low, right.low)
+    left.high &+= right.high
+}
+
+// -------------------------------------
+/// Subtract a digit from a tuple, borrowing the high part if necessary
+@usableFromInline @inline(__always)
+func -= (left: inout (high: UInt64, low: UInt64), right: UInt64) {
+    left.high &-= subtractReportingBorrow(&left.low, right)
+}

--- a/Sources/Euler/Utility/KnuthDSupport.swift
+++ b/Sources/Euler/Utility/KnuthDSupport.swift
@@ -134,21 +134,13 @@ internal func += (left: inout Limbs.SubSequence, right: Limbs.SubSequence)
     - shift: the number of bits to shift `x` by.
     - y: Storage for the resulting shift of `x`.  May alias `x`.
  */
-internal func leftShift<T, U>(_ x: T, by shift: Int, into y: inout U)
-    where
-    T: RandomAccessCollection,
-    T.Element == UInt64,
-    T.Index == Int,
-    U: RandomAccessCollection,
-    U: MutableCollection,
-    U.Element == T.Element,
-    U.Index == T.Index
+internal func leftShift(_ x: Limbs, by shift: Int, into y: inout Limbs)
 {
     assert(y.count >= x.count)
     assert(y.startIndex == x.startIndex)
     
-    let bitWidth = MemoryLayout<T.Element>.size * 8
-    
+    let bitWidth = UInt64.bitWidth
+
     for i in (1..<x.count).reversed() {
         y[i] = (x[i] << shift) | (x[i - 1] >> (bitWidth - shift))
     }
@@ -166,25 +158,15 @@ internal func leftShift<T, U>(_ x: T, by shift: Int, into y: inout U)
     - shift: the number of bits to shift `x` by.
     - y: Storage for the resulting shift of `x`.  May alias `x`.
  */
-internal func rightShift<T, U>(_ x: T, by shift: Int, into y: inout U)
-    where
-    T: RandomAccessCollection,
-    T.Element == UInt64,
-    T.Index == Int,
-    U: RandomAccessCollection,
-    U: MutableCollection,
-    U.Element == T.Element,
-    U.Index == T.Index
+internal func rightShift(_ x: inout Limbs.SubSequence, by shift: Int)
 {
-    assert(y.count == x.count)
-    assert(y.startIndex == x.startIndex)
-    let bitWidth = MemoryLayout<T.Element>.size * 8
+    let bitWidth = UInt64.bitWidth
     
     let lastElemIndex = x.count - 1
     for i in 0..<lastElemIndex {
-        y[i] = (x[i] >> shift) | (x[i + 1] << (bitWidth - shift))
+        x[i] = (x[i] >> shift) | (x[i + 1] << (bitWidth - shift))
     }
-    y[lastElemIndex] = x[lastElemIndex] >> shift
+    x[lastElemIndex] = x[lastElemIndex] >> shift
 }
 
 // -------------------------------------

--- a/Sources/Euler/Utility/KnuthDSupport.swift
+++ b/Sources/Euler/Utility/KnuthDSupport.swift
@@ -28,8 +28,9 @@ internal extension FixedWidthInteger
  
  - Returns: Borrow out of the difference.
  */
-@usableFromInline @inline(__always)
-func subtractReportingBorrow<T: FixedWidthInteger>(_ x: inout T, _ y: T) -> T
+internal func subtractReportingBorrow<T: FixedWidthInteger>(
+    _ x: inout T,
+    _ y: T) -> T
 {
     let b: Bool
     (x, b) = x.subtractingReportingOverflow(y)
@@ -47,8 +48,9 @@ func subtractReportingBorrow<T: FixedWidthInteger>(_ x: inout T, _ y: T) -> T
  
  - Returns: Carry out of the sum.
  */
-@usableFromInline @inline(__always)
-func addReportingCarry<T: FixedWidthInteger>(_ x: inout T, _ y: T) -> T
+internal func addReportingCarry<T: FixedWidthInteger>(
+    _ x: inout T,
+    _ y: T) -> T
 {
     let c: Bool
     (x, c) = x.addingReportingOverflow(y)
@@ -70,8 +72,7 @@ func addReportingCarry<T: FixedWidthInteger>(_ x: inout T, _ y: T) -> T
  
  - Returns: The borrow out of the most signficant digit of `y`.
  */
-@usableFromInline @inline(__always)
-func subtractReportingBorrow<T, U>(
+internal func subtractReportingBorrow<T, U>(
     _ x: T,
     times k: T.Element,
     from y: inout U) -> Bool
@@ -115,8 +116,7 @@ func subtractReportingBorrow<T, U>(
         collection of digits with the the least signficant digit at index 0
         (ie. little endian).
  */
-@usableFromInline @inline(__always)
-func += <T, U>(left: inout U, right: T )
+internal func += <T, U>(left: inout U, right: T )
     where T: RandomAccessCollection,
     T.Element == UInt64,
     T.Index == Int,
@@ -153,8 +153,7 @@ func += <T, U>(left: inout U, right: T )
     - shift: the number of bits to shift `x` by.
     - y: Storage for the resulting shift of `x`.  May alias `x`.
  */
-@usableFromInline @inline(__always)
-func leftShift<T, U>(_ x: T, by shift: Int, into y: inout U)
+internal func leftShift<T, U>(_ x: T, by shift: Int, into y: inout U)
     where
     T: RandomAccessCollection,
     T.Element == UInt64,
@@ -186,8 +185,7 @@ func leftShift<T, U>(_ x: T, by shift: Int, into y: inout U)
     - shift: the number of bits to shift `x` by.
     - y: Storage for the resulting shift of `x`.  May alias `x`.
  */
-@usableFromInline @inline(__always)
-func rightShift<T, U>(_ x: T, by shift: Int, into y: inout U)
+internal func rightShift<T, U>(_ x: T, by shift: Int, into y: inout U)
     where
     T: RandomAccessCollection,
     T.Element:BinaryInteger,
@@ -221,8 +219,7 @@ func rightShift<T, U>(_ x: T, by shift: Int, into y: inout U)
 
 - Returns: A single digit remainder.
  */
-@usableFromInline @inline(__always)
-func divide<T, U>(_ x: T, by y: T.Element, result z: inout U) -> T.Element
+internal func divide<T, U>(_ x: T, by y: T.Element, result z: inout U) -> T.Element
     where T: RandomAccessCollection,
     T.Element == UInt64,
     T.Index == Int,
@@ -259,7 +256,6 @@ directly.
 
 // -------------------------------------
 /// Multiply a tuple of digits by 1 digit
-@usableFromInline @inline(__always)
 internal func * (left: (high: UInt64, low: UInt64), right: UInt64)
     -> (high: UInt64, low: UInt64)
 {
@@ -276,7 +272,6 @@ infix operator /% : MultiplicationPrecedence
 
 // -------------------------------------
 /// Divide a tuple of digits by 1 digit obtaining both quotient and remainder
-@usableFromInline @inline(__always)
 internal func /% (left: (high: UInt64, low: UInt64), right: UInt64)
     -> (
         quotient: (high: UInt64, low: UInt64),
@@ -300,7 +295,6 @@ internal func /% (left: (high: UInt64, low: UInt64), right: UInt64)
     optimization to avoid hidden conditional branches in boolean expressions.
  */
 
-@usableFromInline @inline(__always)
 internal func > (
     left: (high: UInt64, low: UInt64),
     right: (high: UInt64, low: UInt64)) -> UInt8
@@ -311,15 +305,13 @@ internal func > (
 
 // -------------------------------------
 /// Add a digit to a tuple's low part, carrying to the high part.
-@usableFromInline @inline(__always)
-func += (left: inout (high: UInt64, low: UInt64), right: UInt64) {
+internal func += (left: inout (high: UInt64, low: UInt64), right: UInt64) {
     left.high &+= addReportingCarry(&left.low, right)
 }
 
 // -------------------------------------
 /// Add one tuple to another tuple
-@usableFromInline @inline(__always)
-func += (
+internal func += (
     left: inout (high: UInt64, low: UInt64),
     right: (high: UInt64, low: UInt64))
 {
@@ -329,7 +321,6 @@ func += (
 
 // -------------------------------------
 /// Subtract a digit from a tuple, borrowing the high part if necessary
-@usableFromInline @inline(__always)
-func -= (left: inout (high: UInt64, low: UInt64), right: UInt64) {
+internal func -= (left: inout (high: UInt64, low: UInt64), right: UInt64) {
     left.high &-= subtractReportingBorrow(&left.low, right)
 }


### PR DESCRIPTION
The Knuth algorithm is fully incorporated in divMod - and not calling out to it as a separate function.  It's fully 64-bit.  I moved the old shift-subtract algorithm into a debugging helper function that I call in an assertion before returning to verify that they return identical results.  They do.  It also means that for debug builds both algorithms are called.  Once you're satisfied with it, you'll want to remove that assertion.  The helper function itself might be a useful sanity check to keep around for when you might want to modify the code later.

Since the algorithm has some specific requirements, there is some preflight code to handle cases that shouldn't be done with the algorithm.  They handle some special cases like when the divisor is greater than the dividend, or when the divisor has only one limb.   I was also able to remove all the old preflight assertions I had, because the divMod function itself now guarantees that they are met before starting the division.

My optimizations are still in the code,  but they can be undone if you like.  It would make the code a little slower, but they are micro-optimizations.  One significant thing I did was just return the remainder directly from the array in which it was created.  My original generic code couldn't assume that was OK, but in this case, it clearly is. That removes an unnecessary array allocation. 

I've also added comments explaining the steps of the algorithm.   Comments are a double-edged sword.  They can help explain complex code, but they also interrupt visual code flow and can of course since they aren't compiled, they can become wrong over time if the code is changed.  They're there for now.  If you think it's better without them, you can delete them. 